### PR TITLE
Fix missing warnings import

### DIFF
--- a/Bot-Trading_Swing.py
+++ b/Bot-Trading_Swing.py
@@ -6,6 +6,7 @@ print("🚀 [Bot] Starting imports...")
 # ==================================================
 import sys
 import os
+import warnings
 
 # Ensure UTF-8 encoding for stdout and stderr
 if hasattr(sys.stdout, 'reconfigure'):
@@ -51,7 +52,6 @@ import re
 import sqlite3
 import time
 import threading
-import warnings
 import argparse
 import hashlib
 import signal


### PR DESCRIPTION
Move `warnings` import to the top of the file and remove duplicate to resolve `NameError`.

---
<a href="https://cursor.com/background-agent?bcId=bc-e4ed932b-4045-4496-9138-334d8a0544ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e4ed932b-4045-4496-9138-334d8a0544ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

