### PR TITLE
Fix missing api key for news provider

### DIFF
--- a/Bot-Trading_Swing.py
+++ b/Bot-Trading_Swing.py
@@ -6992,7 +6992,7 @@ class NewsProvider(ABC):
             "published_at": published_at
         }
 
-class FinnhubProvider(NewsProvider):
+class FinnhubNewsProvider(NewsProvider):
     async def fetch_news(self, session, symbol: str, stock_map: dict):
         if not self.enabled: return []
         stock_symbol = stock_map.get(symbol, symbol)
@@ -7318,7 +7318,7 @@ class NewsEconomicManager:
         
         # Initialize providers
         providers = [
-            ("Finnhub", FinnhubProvider(finnhub_key)),
+            ("Finnhub", FinnhubNewsProvider(finnhub_key)),
             ("Marketaux", MarketauxProvider(marketaux_key)),
             ("NewsAPI.org", NewsApiOrgProvider(newsapi_key)),
             ("EODHD", EODHDProvider(eodhd_key))


### PR DESCRIPTION
Rename `FinnhubProvider` (news) to `FinnhubNewsProvider` to resolve a `TypeError` caused by a class naming conflict.

A `TypeError` occurred because two classes were named `FinnhubProvider` in the same file. This led to the `ResilientPriceAggregator` incorrectly instantiating the `NewsProvider` version (which requires an `api_key`), instead of the `PriceProvider` version. Renaming the news provider class and updating its usage resolves this ambiguity.

---
<a href="https://cursor.com/background-agent?bcId=bc-fc59ebbb-a21c-42a8-a1c5-31ac8a5b917a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-fc59ebbb-a21c-42a8-a1c5-31ac8a5b917a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

