### PR TITLE
Fix EODHDProvider api key error

### DIFF
--- a/Bot-Trading_Swing.py
+++ b/Bot-Trading_Swing.py
@@ -7035,7 +7035,7 @@ class FinnhubNewsProvider(NewsProvider):
 
 # TM V THAY THTON BL P this
 
-class EODHDProvider(NewsProvider):
+class EODHDNewsProvider(NewsProvider):
     def __init__(self, api_key):
         super().__init__(api_key)
         if self.enabled:


### PR DESCRIPTION
Rename duplicate `EODHDProvider` (NewsProvider) to `EODHDNewsProvider` to fix `TypeError`.

The `ResilientPriceAggregator` was attempting to instantiate `EODHDProvider()` and was incorrectly resolving to the `EODHDProvider` class intended for news (which required an `api_key`), instead of the `EODHDProvider` class intended for price aggregation (which had an optional `api_key`). Renaming the news provider class resolves this ambiguity.

---
<a href="https://cursor.com/background-agent?bcId=bc-d2dc11dc-677e-4e78-83a8-56843bbd863a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d2dc11dc-677e-4e78-83a8-56843bbd863a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

