### PR TITLE
Fix master agent config argument

### DIFF
--- a/Bot-Trading_Swing.py
+++ b/Bot-Trading_Swing.py
@@ -15780,7 +15780,9 @@ class EnhancedTradingBot:
         
         # Advanced Master Agent System for TP/SL Decisions
         print("🎯 [Bot Init] Initializing Master Agent for TP/SL decisions...")
-        self.master_agent_coordinator = MasterAgent()
+        # Create a default config for MasterAgent initialization
+        default_config = Config()
+        self.master_agent_coordinator = MasterAgent(default_config)
         print("✅ [Bot Init] Master Agent initialized successfully")
         
         # Advanced Ensemble System
@@ -24336,6 +24338,7 @@ if __name__ == "__main__":
         # Inject new components into bot
         bot.config = config
         bot.master_agent = master_agent
+        bot.master_agent_coordinator = master_agent  # Update the coordinator with the properly configured agent
         bot.monitor = monitor
         bot.price_aggregator = _price_aggregator
         bot.logging_manager = _logging_manager


### PR DESCRIPTION
Fix `TypeError` in `MasterAgent` initialization by providing a default config and updating it with the actual config later.

The `MasterAgent` was instantiated in `EnhancedTradingBot.__init__` without a `config` argument, leading to a `TypeError`. The `config` object is only available later in the main execution block. This PR addresses the issue by:
1. Initializing `MasterAgent` with a temporary `default_config` in `EnhancedTradingBot.__init__` to allow the bot to start.
2. Updating `bot.master_agent_coordinator` with the fully configured `master_agent` once the main `config` is loaded, ensuring the correct configuration is used.

---
<a href="https://cursor.com/background-agent?bcId=bc-5ce058ce-5c51-43f6-98ef-4c2193b844fd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5ce058ce-5c51-43f6-98ef-4c2193b844fd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

