### PR TITLE
Initialize trading bot and handle news provider error

### DIFF
--- a/Bot-Trading_Swing.py
+++ b/Bot-Trading_Swing.py
@@ -7321,7 +7321,7 @@ class NewsEconomicManager:
             ("Finnhub", FinnhubNewsProvider(finnhub_key)),
             ("Marketaux", MarketauxProvider(marketaux_key)),
             ("NewsAPI.org", NewsApiOrgProvider(newsapi_key)),
-            ("EODHD", EODHDProvider(eodhd_key))
+            ("EODHD", EODHDNewsProvider(eodhd_key))
         ]
         
         enabled_count = 0


### PR DESCRIPTION
Replace `EODHDProvider` with `EODHDNewsProvider` in `NewsEconomicManager` initialization.

The `NewsEconomicManager` was attempting to use `EODHDProvider` (a price provider) as a news provider, which caused an `AttributeError` because `EODHDProvider` lacks the `enabled` attribute expected by news providers. Switching to `EODHDNewsProvider` resolves this by using the correct news-specific class that includes the necessary `enabled` attribute.

---
<a href="https://cursor.com/background-agent?bcId=bc-52f2d156-8118-42b1-8466-9ef6f5e8d96d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-52f2d156-8118-42b1-8466-9ef6f5e8d96d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

